### PR TITLE
Button position fixes

### DIFF
--- a/basic/app.css
+++ b/basic/app.css
@@ -3,17 +3,17 @@ body {
 }
 #zoom-buttons {
   position: absolute;
-  top: 66px;
-  margin-left: 10px;
+  top: 86px;
+  margin-left: 20px;
   z-index: 1111;
 }
 #layerlist {
   position: absolute;
-  right: 10px;
-  top: 66px;
+  right: 20px;
+  top: 86px;
 }
 .layerlistbutton {
-  position: absolute;
+  position: absolute !important;
   right: 0px;
   top: 0px;
 }
@@ -23,11 +23,11 @@ body {
 #globe-button {
   z-index: 1111;
   position: absolute;
-  top: 180px;
-  margin-left: 10px;
+  top: 195px;
+  margin-left: 20px;
 }
 .layer-switcher {
-  top: 66px !important;
+  top: 76px !important;
 }
 .edit-tool-panel {
   display: none;

--- a/bookmarks/app.css
+++ b/bookmarks/app.css
@@ -21,7 +21,7 @@ body {
   height: 100%;
 }
 #zoom-buttons {
-  margin-left: 10px;
+  margin-left: 20px;
   position: absolute;
-  top: 10px;
+  top: 20px;
 }

--- a/plugin/app.css
+++ b/plugin/app.css
@@ -48,11 +48,11 @@ html, body {
 #zoom-buttons {
   margin-left: 20px;
   position: absolute;
-  top: 76px;
+  top: 86px;
 }
 #layer-list {
   position: absolute;
-  top: 76px;
+  top: 86px;
   right: 20px;
 }
 .layerlistbutton {


### PR DESCRIPTION
Some minor position changes to keep a standard of 20px padding around sdk buttons.

Before
<img width="74" alt="screen shot 2017-05-04 at 4 21 54 pm" src="https://cloud.githubusercontent.com/assets/410285/25723441/02e7cd5c-30e6-11e7-8cdc-0d4c7b4f3627.png">
After
<img width="86" alt="screen shot 2017-05-04 at 4 23 01 pm" src="https://cloud.githubusercontent.com/assets/410285/25723446/0acc6b7c-30e6-11e7-8dca-26e6fe35422b.png">

Also fixed the layer list button moving around on the basic example:
Before
<img width="438" alt="screen shot 2017-05-04 at 4 22 34 pm" src="https://cloud.githubusercontent.com/assets/410285/25723458/142e028e-30e6-11e7-876b-d07ce304d9bb.png">
After
<img width="458" alt="screen shot 2017-05-04 at 4 23 19 pm" src="https://cloud.githubusercontent.com/assets/410285/25723463/1a1470d4-30e6-11e7-8014-edfb74a8ba56.png">


